### PR TITLE
Don't #define _BSD_SOURCE

### DIFF
--- a/lib/unix_fcntl_stubs.c
+++ b/lib/unix_fcntl_stubs.c
@@ -15,7 +15,7 @@
  *
  */
 
-#define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 #define _POSIX_C_SOURCE 200809L
 
 #include <stdint.h>


### PR DESCRIPTION
Is this the right change? (See below for the C error I get)

```
tr61@pc1177:/tmp/l/bitbucket/fs/.nix/ocaml-unix-fcntl$ nix-build
these derivations will be built:
  /nix/store/ra9pwwxffw472a656xv9vax1p1ifs4jg-ocaml-unix-fcntl-10f689.drv
  /nix/store/ljcnhji4mhjlla1y2x9jbqxdsgafck1y-ocaml-unix-fcntl.drv
building path(s) ‘/nix/store/7azbjvf28kawisiqnd26dqqqw2dx3nz2-ocaml-unix-fcntl-10f689’
exporting https://github.com/dsheets/ocaml-unix-fcntl.git (rev 10f689) into /nix/store/7azbjvf28kawisiqnd26dqqqw2dx3nz2-ocaml-unix-fcntl-10f689
Initialized empty Git repository in /nix/store/7azbjvf28kawisiqnd26dqqqw2dx3nz2-ocaml-unix-fcntl-10f689/.git/
remote: Counting objects: 65, done.
remote: Total 65 (delta 0), reused 0 (delta 0), pack-reused 65
From https://github.com/dsheets/ocaml-unix-fcntl
 * [new branch]      master     -> origin/master
Switched to a new branch 'fetchgit'
git revision is 10f689d7417d195aa4f7fe054af6e53ed1c34aab
git human-readable version is -- none --
Commit date is 2015-07-23 17:08:39 +0100
removing `.git'...
building path(s) ‘/nix/store/sb8nnch57i104qqdp78dqmppn5hyra39-ocaml-unix-fcntl’
unpacking sources
unpacking source archive /nix/store/7azbjvf28kawisiqnd26dqqqw2dx3nz2-ocaml-unix-fcntl-10f689
source root is ocaml-unix-fcntl-10f689
patching sources
configuring
no configure script, doing nothing
building
make flags: SHELL=/nix/store/dbxpkswwc7rh6g1iy6dwqklzw39hihb1-bash-4.3-p33/bin/bash
ocamlfind: Package `ctypes.foreign' not found
mkdir -p _build/lib
cc -c -fPIC -Wall -Wextra -Werror -std=c99 -o _build/lib/unix_fcntl_stubs.o lib/unix_fcntl_stubs.c -I/nix/store/7kb8di6xz5gfpbwx0l3d2bb1yr9jq8ga-ocaml-4.01.0/lib/ocaml
In file included from /nix/store/i0l0jjkk82wsqz9z5yhg35iy78bjq684-glibc-2.21/include/stdint.h:25:0,
                 from /nix/store/cpv8pyc772cx0spzz76sa6dvsf6555dh-gcc-4.8.4/lib/gcc/x86_64-unknown-linux-gnu/4.8.4/include/stdint.h:9,
                 from lib/unix_fcntl_stubs.c:21:
/nix/store/i0l0jjkk82wsqz9z5yhg35iy78bjq684-glibc-2.21/include/features.h:148:3: error: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Werror=cpp]
 # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
   ^
cc1: all warnings being treated as errors
Makefile:22: recipe for target 'build' failed
make: *** [build] Error 1
builder for ‘/nix/store/ljcnhji4mhjlla1y2x9jbqxdsgafck1y-ocaml-unix-fcntl.drv’ failed with exit code 2
error: build of ‘/nix/store/ljcnhji4mhjlla1y2x9jbqxdsgafck1y-ocaml-unix-fcntl.drv’ failed
```