### PR TITLE
ocaml-unix-fcntl requires OCaml 4.02.0 or later.

### DIFF
--- a/opam
+++ b/opam
@@ -25,3 +25,4 @@ depopts: [
   "lwt"
   "base-threads"
 ]
+available: [ ocaml-version >= "4.02.0" ]


### PR DESCRIPTION
`Fcntl` [uses](https://github.com/dsheets/ocaml-unix-fcntl/blob/3eafa4f77cc40b3618098bdc02e0f50d8b104bb4/lib/fcntl.ml#L365) `match`/`exception`.