### PR TITLE
Rename Fcntl.Oflag.to_code to Fcntl.Oflag.to_code_exn

### DIFF
--- a/lib/fcntl.ml
+++ b/lib/fcntl.ml
@@ -266,7 +266,10 @@ module Oflags = struct
     in fun code -> bit lor code
 
   (* This can't roundtrip [] because O_RDONLY is 0 *)
-  let to_code ~host = List.fold_left (fun code t -> set ~host t code) 0
+  let to_code_exn ~host = List.fold_left (fun code t -> set ~host t code) 0
+
+  let to_code ~host l =
+    try Some (to_code_exn ~host l) with Not_found -> None
 
   let with_code defns symbol code = match symbol with
     | O_RDONLY    -> { defns with o_rdonly = code }

--- a/lib/fcntl.ml
+++ b/lib/fcntl.ml
@@ -260,13 +260,15 @@ module Oflags = struct
     in fun code -> exist && match t with
     | O_RDONLY | O_TTY_INIT -> code = bit
     | _ -> (bit land code) = bit
-  let set ~host t =
+  let set_exn ~host t =
     let bit = match _to_code ~host t with
       | Some bit -> bit | None -> raise Not_found
     in fun code -> bit lor code
+  let set ~host t code =
+    try Some (set_exn ~host t code) with Not_found -> None
 
   (* This can't roundtrip [] because O_RDONLY is 0 *)
-  let to_code_exn ~host = List.fold_left (fun code t -> set ~host t code) 0
+  let to_code_exn ~host = List.fold_left (fun code t -> set_exn ~host t code) 0
 
   let to_code ~host l =
     try Some (to_code_exn ~host l) with Not_found -> None

--- a/lib/fcntl.mli
+++ b/lib/fcntl.mli
@@ -97,7 +97,8 @@ module Oflags : sig
   val of_code : host:Host.t -> int -> t list
 
   val is_set : host:Host.t -> t -> int -> bool
-  val set : host:Host.t -> t -> int -> int
+  val set : host:Host.t -> t -> int -> int option
+  val set_exn : host:Host.t -> t -> int -> int
 
   val to_string : t -> string
 

--- a/lib/fcntl.mli
+++ b/lib/fcntl.mli
@@ -92,7 +92,8 @@ module Oflags : sig
       -> (int -> unit) -> (int -> oflag -> unit) -> (oflag -> unit) -> unit
   end
 
-  val to_code : host:Host.t -> t list -> int
+  val to_code : host:Host.t -> t list -> int option
+  val to_code_exn : host:Host.t -> t list -> int
   val of_code : host:Host.t -> int -> t list
 
   val is_set : host:Host.t -> t -> int -> bool

--- a/lwt/fcntl_unix_lwt.ml
+++ b/lwt/fcntl_unix_lwt.ml
@@ -26,7 +26,7 @@ let raise_errno_error ~call ~label errno =
 let open_ : string -> ?perms:int -> Fcntl.Oflags.t list -> Unix.file_descr Lwt.t
   = fun name ?perms flags ->
     let open Lwt in
-    let flags = Fcntl.Oflags.to_code ~host:Fcntl_unix.host.Fcntl.Host.oflags flags in
+    let flags = Fcntl.Oflags.to_code_exn ~host:Fcntl_unix.host.Fcntl.Host.oflags flags in
     Lwt_unix.run_job (make_open_job ~name ~flags ~perms) >>= fun (fd, errno) ->
     if Unix_representations.int_of_file_descr fd < 0
     then raise_errno_error ~call:"open" ~label:name errno

--- a/unix/fcntl_unix.ml
+++ b/unix/fcntl_unix.ml
@@ -110,9 +110,6 @@ module Oflags = struct
     })) in
     Oflags.Host.of_defns defns
 
-  let view ~host = Oflags.(
-    Ctypes.(view ~read:(of_code ~host) ~write:(to_code ~host) int)
-  )
 end
 
 let host = {
@@ -120,7 +117,7 @@ let host = {
 }
 
 let open_ path ?perms oflags =
-  let oflags = Fcntl.(Oflags.to_code ~host:host.Host.oflags oflags) in
+  let oflags = Fcntl.(Oflags.to_code_exn ~host:host.Host.oflags oflags) in
   Errno_unix.raise_on_errno ~call:"open" ~label:path (fun () ->
     match perms with
     | None       -> C.open_ (Some path) oflags


### PR DESCRIPTION
Rename `Fcntl.Oflag.to_code` to `Fcntl.Oflag.to_code_exn` and add a new `Fcntl.Oflag.to_code` that returns `int option`.

Fixes #6.