### PR TITLE
Fix lwt errno

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,6 +1,7 @@
 PKG ctypes
 PKG unix-errno
 PKG lwt
+PKG alcotest
 
 S lib
 S lib_gen

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,12 @@ language: c
 sudo: false
 services:
   - docker
-install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-docker.sh
+install: wget https://raw.githubusercontent.com/dsheets/ocaml-travisci-skeleton/baseless-removal-demands/.travis-docker.sh
 script: bash ./.travis-docker.sh
 env:
  global:
+   - FORK_USER="dsheets"
+   - FORK_BRANCH="baseless-removal-demands"
    - PACKAGE="unix-fcntl"
    - DEPOPTS="*"
  matrix:

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+0.3.1 (2016-04-22):
+* Fix a bug with `Fcntl_unix_lwt.open_` errors always as `EPERM`
+
 0.3.0 (2016-04-15):
 * Reorganise the Fcntl interface, adding submodules Host and Oflags.Host.
 * Add the Fcntl_host module

--- a/META
+++ b/META
@@ -1,4 +1,4 @@
-version = "0.3.0"
+version = "0.3.1"
 description = "Unix fcntl types, maps, and support"
 requires = ""
 archive(byte) = "fcntl.cma"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ in the standard OCaml `Unix` module.  The [`Fcntl_unix_lwt`][fcntl_unix_lwt]
 module exports non-blocking versions of the functions in `Fcntl_unix` based on
 the [`Lwt`][lwt] cooperative threading library.
 
+Currently open flags and the `open(2)` function are bound.
+
 [fcntl.h]: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/fcntl.h.html
 [fcntl]: https://github.com/dsheets/ocaml-unix-fcntl/blob/master/lib/fcntl.mli
 [fcntl_host]: https://github.com/dsheets/ocaml-unix-fcntl/blob/master/lib/fcntl_host.mli

--- a/lwt/unix_fcntl_lwt_stubs.c
+++ b/lwt/unix_fcntl_lwt_stubs.c
@@ -51,7 +51,7 @@ static value result_open(struct job_open *job)
 {
   value result = caml_alloc_tuple(2);
   Field(result, 0) = Val_int(job->fd);
-  Field(result, 1) = Val_bool(job->error_code);
+  Field(result, 1) = Val_int(job->error_code);
   lwt_unix_free_job(&job->job);
   return result;
 }

--- a/lwt_test/test.ml
+++ b/lwt_test/test.ml
@@ -52,10 +52,17 @@ struct
         raise e
     end;
     cleanup ()
-      
+
+  let errno () =
+    Alcotest.check_raises "ENOENT fails with ENOENT"
+      Errno.(Error { errno = [ ENOENT ]; call = "open"; label = "ENOENT" })
+      (fun () ->
+         ignore (Lwt_unix.run (Fcntl_unix_lwt.open_ "ENOENT" []))
+      )
 
   let tests = [
     "nofollow", `Quick, nofollow;
+    "errno", `Quick, errno;
   ]
 end
 

--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
 name: "unix-fcntl"
-version: "0.3.0"
+version: "0.3.1"
 maintainer: "sheets@alum.mit.edu"
 authors: ["David Sheets" "Jeremy Yallop"]
 homepage: "https://github.com/dsheets/ocaml-unix-fcntl"


### PR DESCRIPTION
`Fcntl_unix_lwt.open_` errors would always be `EPERM` (1) due to an incorrect `bool` coercion. Now they are the actual errno.