### PR TITLE
Updates for unix-errno 0.5.0

### DIFF
--- a/META
+++ b/META
@@ -8,7 +8,7 @@ archive(native, plugin) = "fcntl.cmxs"
 exists_if = "fcntl.cma"
 
 package "unix" (
-  requires = "unix ctypes.stubs unix-fcntl unix-errno.unix"
+  requires = "unix ctypes.stubs unix-fcntl unix-errno.unix unix-type-representations ctypes"
   archive(byte) = "unix_fcntl.cma"
   archive(bytes, plugin) = "unix_fcntl.cma"
   archive(native) = "unix_fcntl.cmxa"

--- a/lwt/_tags
+++ b/lwt/_tags
@@ -1,4 +1,4 @@
 <*.{ml,mli}>: package(lwt.preemptive), thread, package(unix-errno)
-<*.{ml,mli}>: package(unix-type-representations)
+<*.{ml,mli}>: package(unix-type-representations), package(ctypes)
 <unix_fcntl_lwt_stubs.c>: use_lwt
 <*.{cma,cmxa}>: use_fcntl_lwt_stubs

--- a/lwt/fcntl_unix_lwt.ml
+++ b/lwt/fcntl_unix_lwt.ml
@@ -33,5 +33,5 @@ let open_
     Lwt_unix.run_job (make_open_job ~name ~flags ~perms)
     >>= fun (fd, errno) ->
     if Unix_representations.int_of_file_descr fd < 0
-    then raise_errno_error ~call:"open" ~label:name errno
+    then raise_errno_error ~call:"open" ~label:name (Signed.SInt.of_int errno)
     else Lwt.return fd

--- a/opam
+++ b/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ctypes" {>= "0.4.0"}
-  "unix-errno" {>= "0.4.0"}
+  "unix-errno" {>= "0.5.0"}
   "alcotest" {test}
   "unix-type-representations"
 ]


### PR DESCRIPTION
`errno` is now a `sint`, not an `int`.