### PR TITLE
Support OCaml 4.05 and 4.06

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ env:
    - PACKAGE="unix-fcntl"
    - DEPOPTS="*"
  matrix:
-   - DISTRO=debian-stable OCAML_VERSION=4.02.3
-   - DISTRO=debian-testing OCAML_VERSION=4.02.3
-   - DISTRO=debian-unstable OCAML_VERSION=4.02.3
-   - DISTRO=ubuntu-12.04 OCAML_VERSION=4.02.3
-   - DISTRO=ubuntu-15.10 OCAML_VERSION=4.02.3
-   - DISTRO=ubuntu-16.04 OCAML_VERSION=4.02.3
-   - DISTRO=centos-6 OCAML_VERSION=4.02.3
-   - DISTRO=centos-7 OCAML_VERSION=4.02.3
-   - DISTRO=fedora-23 OCAML_VERSION=4.02.3
+   - DISTRO=debian-stable OCAML_VERSION=4.05.0
+   - DISTRO=debian-testing OCAML_VERSION=4.05.0
+   - DISTRO=debian-unstable OCAML_VERSION=4.05.0
+   - DISTRO=ubuntu-12.04 OCAML_VERSION=4.05.0
+   - DISTRO=ubuntu-15.10 OCAML_VERSION=4.05.0
+   - DISTRO=ubuntu-16.04 OCAML_VERSION=4.05.0
+   - DISTRO=centos-6 OCAML_VERSION=4.05.0
+   - DISTRO=centos-7 OCAML_VERSION=4.05.0
+   - DISTRO=fedora-23 OCAML_VERSION=4.05.0

--- a/opam
+++ b/opam
@@ -27,4 +27,4 @@ depopts: [
   "lwt"
   "base-threads"
 ]
-available: [ ocaml-version >= "4.02.0" ]
+available: [ ocaml-version >= "4.05.0" ]

--- a/unix/fcntl_unix.ml
+++ b/unix/fcntl_unix.ml
@@ -69,6 +69,7 @@ module Oflags = struct
     | Unix.O_SYNC     -> O_SYNC
     | Unix.O_RSYNC    -> O_RSYNC
     | Unix.O_CLOEXEC  -> O_CLOEXEC
+    | Unix.O_KEEPEXEC
     | Unix.O_SHARE_DELETE -> raise Not_found
   )
 


### PR DESCRIPTION
OCaml 4.05 introduced O_KEEPEXEC which is a synthetic flag similar to
O_SHARE_DELETE. This patch extends the pattern match to cover it.

This patch also bumps the minimum OCaml version to 4.05.0 to match.

Signed-off-by: David Scott <dave@recoil.org>